### PR TITLE
Do not nest results under `json` key in the output.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6,6 +6,10 @@
 name: CICD
 "on":
   workflow_dispatch:
+  pull_request:
+  push:
+    tags:
+      - "v*"
 
 jobs:
   prepare-matrix:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -68,6 +68,6 @@ issues: https://github.com/nokia/srlinux-ansible-collection/issues
 build_ignore:
   - scripts
   - run.sh
-  - tests
+  # - tests
   - .github
   - .vscode

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -68,6 +68,5 @@ issues: https://github.com/nokia/srlinux-ansible-collection/issues
 build_ignore:
   - scripts
   - run.sh
-  # - tests
   - .github
   - .vscode

--- a/plugins/modules/jsonrpc_cli.py
+++ b/plugins/modules/jsonrpc_cli.py
@@ -75,15 +75,23 @@ def main():
     }
     ret = client.post(payload=json.dumps(data))
 
-    if ret:
-        json_output["changed"] = True
-        json_output["json"] = ret
-        module.exit_json(**json_output)
-        return
+    # populate the output using custom keys
+    json_output["jsonrpc_req_id"] = ret["id"]
+    json_output["jsonrpc_version"] = ret["jsonrpc"]
+    json_output["result"] = ret.get("result")
+    err = ret.get("error")
+    if err:
+        json_output["error"] = err
 
-    json_output["ret"] = ret
+    if ret and ret.get("result"):
+        module.exit_json(**json_output)
+
+    # handling error case
     json_output["failed"] = True
-    module.exit_json(**json_output)
+    module.fail_json(
+        msg=json_output["error"]["message"],
+        jsonrpc_req_id=json_output["jsonrpc_req_id"],
+    )
 
 
 if __name__ == "__main__":

--- a/plugins/modules/jsonrpc_get.py
+++ b/plugins/modules/jsonrpc_get.py
@@ -97,14 +97,22 @@ def main():
     }
 
     ret = client.post(payload=json.dumps(data))
-    json_output["json"] = ret
+    # populate the output using custom keys
+    json_output["jsonrpc_req_id"] = ret["id"]
+    json_output["jsonrpc_version"] = ret["jsonrpc"]
+    json_output["result"] = ret.get("result")
+    err = ret.get("error")
+    if err:
+        json_output["error"] = err
 
     if ret and ret.get("result"):
         module.exit_json(**json_output)
 
+    # handling error case
     json_output["failed"] = True
     module.fail_json(
-        msg=json_output["json"]["error"]["message"], id=json_output["json"]["id"]
+        msg=json_output["error"]["message"],
+        jsonrpc_req_id=json_output["jsonrpc_req_id"],
     )
 
 

--- a/run.sh
+++ b/run.sh
@@ -138,6 +138,12 @@ function test-cli-show-version {
   ansible-playbook playbooks/cli-show-version.yml "$@"
 }
 
+function test-cli-wrong-cmd {
+  _cdTests
+  revert-to-checkpoint
+  ansible-playbook playbooks/cli-wrong-cmd.yml "$@"
+}
+
 function test-set-check-mode {
   _cdTests
   revert-to-checkpoint
@@ -190,6 +196,7 @@ function _run-tests {
   test-config-backup "$@"
   test-get-wrong-path "$@"
   test-cli-show-version "$@"
+  test-cli-wrong-cmd "$@"
   test-tls-fail "$@"
   test-tls-skip "$@"
   test-set-check-mode "$@"

--- a/run.sh
+++ b/run.sh
@@ -69,7 +69,7 @@ function prepare-dev-env {
   ln -s "$(pwd)" /tmp/srl_ansible_dev/ansible_collections/nokia/srl
 
   # setup .env file for python to resolve imports
-  echo "PYTHONPATH=/tmp/srl_ansible_dev" > .env
+  echo "PYTHONPATH=$(realpath ~)/.ansible/collections:/tmp/srl_ansible_dev" > .env
 }
 
 # revert to initial checkpoint to guarantee the node initial state

--- a/tests/hosts
+++ b/tests/hosts
@@ -1,2 +1,2 @@
 [clab]
-clab-ansible-srl     ansible_connection=ansible.netcommon.httpapi    ansible_user=admin  ansible_password=NokiaSrl1! ansible_network_os=nokia.srl.srlinux 
+clab-ansible-srl  ansible_connection=ansible.netcommon.httpapi  ansible_user=admin  ansible_password=NokiaSrl1! ansible_network_os=nokia.srl.srlinux  ansible_httpapi_ciphers=ECDHE-RSA-AES256-SHA

--- a/tests/playbooks/backup-cfg.yml
+++ b/tests/playbooks/backup-cfg.yml
@@ -22,12 +22,12 @@
 
     - name: Save fetched config in JSON
       ansible.builtin.copy:
-        content: "{{response.json.result[0] | to_nice_json}}"
+        content: "{{response.result[0] | to_nice_json}}"
         dest: "/tmp/{{inventory_hostname}}.cfg.json"
 
     - name: Save fetched config in YAML
       ansible.builtin.copy:
-        content: "{{response.json.result[0] | to_nice_yaml}}"
+        content: "{{response.result[0] | to_nice_yaml}}"
         dest: "/tmp/{{inventory_hostname}}.cfg.yml"
 
     - name: check if saved file contains "srl_nokia"

--- a/tests/playbooks/cli-wrong-cmd.yml
+++ b/tests/playbooks/cli-wrong-cmd.yml
@@ -2,16 +2,16 @@
 # Licensed under the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 
-- name: Run "show version" CLI command
+- name: Run wrong CLI command
   hosts: clab
   gather_facts: false
   tasks:
-    - name: Run "show version" CLI command
+    - name: Run wrong CLI command
       nokia.srl.jsonrpc_cli:
         commands:
-          - show version
+          - show wrong
       register: response
-      failed_when: response.result[0]["basic system info"].Architecture != "x86_64"
+      failed_when: '("Parsing error: Unknown token" not in response.msg) or (response.failed is not true)'
 
     - debug:
         var: response

--- a/tests/playbooks/delete-leaves.yml
+++ b/tests/playbooks/delete-leaves.yml
@@ -31,7 +31,7 @@
           - path: /system/information
             datastore: state
       register: get_response
-      failed_when: get_response.json.result[0].location is defined or get_response.json.result[0].contact is defined
+      failed_when: get_response.result[0].location is defined or get_response.result[0].contact is defined
 
     - debug:
         var: get_response

--- a/tests/playbooks/get-container.yml
+++ b/tests/playbooks/get-container.yml
@@ -13,7 +13,7 @@
           - path: /system/information
             datastore: state
       register: response
-      failed_when: '"SRLinux" not in response.json.result[0].description'
+      failed_when: '"SRLinux" not in response.result[0].description'
 
     - debug:
         var: response

--- a/tests/playbooks/replace-full-cfg.yml
+++ b/tests/playbooks/replace-full-cfg.yml
@@ -25,7 +25,7 @@
             datastore: state
       register: get_response
       # check if the expected interface description is present as a result of config replace
-      failed_when: ("ethernet-1/1 interface on "+vars.inventory_hostname) not in get_response.json.result[0]
+      failed_when: ("ethernet-1/1 interface on "+vars.inventory_hostname) not in get_response.result[0]
 
     - debug:
         var: get_response

--- a/tests/playbooks/set-check.yml
+++ b/tests/playbooks/set-check.yml
@@ -41,7 +41,7 @@
           - path: /system/information
             datastore: state
       register: get_response
-      failed_when: response.json.result[0].location is defined
+      failed_when: response.result[0].location is defined
 
     - debug:
         var: get_response

--- a/tests/playbooks/set-idempotent.yml
+++ b/tests/playbooks/set-idempotent.yml
@@ -25,7 +25,7 @@
           - path: /system/information
             datastore: state
       register: get_response
-      failed_when: get_response.json.result[0].location != "Some location" or get_response.json.result[0].contact != "Some contact"
+      failed_when: get_response.result[0].location != "Some location" or get_response.result[0].contact != "Some contact"
 
     - debug:
         var: get_response

--- a/tests/playbooks/set-leaves.yml
+++ b/tests/playbooks/set-leaves.yml
@@ -24,7 +24,7 @@
           - path: /system/information
             datastore: state
       register: get_response
-      failed_when: get_response.json.result[0].location != "Some location" or get_response.json.result[0].contact != "Some contact"
+      failed_when: get_response.result[0].location != "Some location" or get_response.result[0].contact != "Some contact"
 
     - debug:
         var: get_response


### PR DESCRIPTION
In this PR I am proposing to change the way the output is formed based in @jbemmel comments.

Instead of nesting the result under `<var>.json.results[0]` it is now `<var>.results[0]` where results list only contains the actual results.

jsonrpc version and request ID have been moved to the top level container and can be now found at
`<var>.jsonrpc_version` and `<var>.jsonrpc_req_id` accordingly.

Example:

```json
ok: [clab-ansible-srl] => {
    "get_response": {
        "changed": false,
        "failed": false,
        "failed_when_result": false,
        "jsonrpc_req_id": 51266,
        "jsonrpc_version": "2.0",
        "result": [
            {
                "contact": "Some contact",
                "current-datetime": "2023-04-19T09:11:29.252Z",
                "description": "SRLinux-v23.3.1-343-gab924f2e64 7220 IXR-D2 Copyright (c) 2000-2020 Nokia. Kernel 5.15.0-67-generic #74-Ubuntu SMP Wed Feb 22 14:14:39 UTC 2023",
                "last-booted": "2023-04-18T17:08:00.383Z",
                "location": "Some location",
                "version": "v23.3.1-343-gab924f2e64"
            }
        ]
    }
}
```

@jbemmel @wdesmedt what do you think?