### PR TITLE
Renaming modules

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,6 @@
+plugin_routing:
+  modules:
+    srl_config:
+      redirect: nokia.srlinux.config
+    srl_get:
+      redirect: nokia.srlinux.get

--- a/plugins/modules/cli.py
+++ b/plugins/modules/cli.py
@@ -3,7 +3,7 @@
 # Licensed under the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Ansible module for jsonrpc cli"""
+"""Ansible module for executing CLI commands to SR Linux devices"""
 
 from __future__ import absolute_import, division, print_function
 
@@ -21,8 +21,8 @@ __metaclass__ = type
 
 DOCUMENTATION = """
 ---
-module: jsonrpc_cli
-short_description: "Implementation of the Nokia SR Linux JSON-RPC's CLI method."
+module: cli
+short_description: "Execute CLI commands on SR Linux devices."
 description:
   - This module allows CLI commands to be executed in Nokia SR Linux using JSON-RPC interface.
 version_added: "0.1.0"
@@ -42,11 +42,10 @@ author:
 
 EXAMPLES = """
 - name: Run \"show version\" CLI command
-  nokia.srlinux.jsonrpc_cli:
+  nokia.srlinux.cli:
     commands:
       - show version
   register: response
-  failed_when: response.json.result[0]["basic system info"].Architecture != "x86_64"
 """
 
 

--- a/plugins/modules/config.py
+++ b/plugins/modules/config.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # -*- coding: utf-8 -*-
-"""Ansible module for jsonrpc set"""
+"""Ansible module for configuring SR Linux devices"""
 
 from __future__ import absolute_import, division, print_function
 
@@ -25,8 +25,8 @@ __metaclass__ = type
 
 DOCUMENTATION = """
 ---
-module: jsonrpc_set
-short_description: "Implementation of the Nokia SR Linux JSON-RPC's Set method."
+module: config
+short_description: "Update, replace and delete configuration on SR Linux devices."
 description:
   - This module allows to set a configuration or run operational transaction. The set method can be used with the candidate and tools datastores.
 version_added: "0.1.0"
@@ -91,7 +91,7 @@ author:
 
 EXAMPLES = """
 - name: Set system information with values
-  nokia.srlinux.jsonrpc_set:
+  nokia.srlinux.config:
     update:
       - path: /system/information
         value:

--- a/plugins/modules/get.py
+++ b/plugins/modules/get.py
@@ -3,7 +3,7 @@
 # Licensed under the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Ansible module for jsonrpc get"""
+"""Ansible module for retrieving configuration and state from SR Linux devices"""
 
 from __future__ import absolute_import, division, print_function
 
@@ -21,8 +21,8 @@ __metaclass__ = type
 
 DOCUMENTATION = """
 ---
-module: jsonrpc_get
-short_description: "Implementation of the Nokia SR Linux JSON-RPC's Get method."
+module: get
+short_description: "Retrieve configuration or state element from Nokia SR Linux devices."
 description:
   - >-
     This module allows to retrieve configuration and state details from the system.
@@ -59,7 +59,7 @@ author:
 
 EXAMPLES = """
 - name: Get /system/information container
-  nokia.srlinux.jsonrpc_get:
+  nokia.srlinux.get:
     paths:
       - path: /system/information
         datastore: state

--- a/plugins/modules/validate.py
+++ b/plugins/modules/validate.py
@@ -2,7 +2,7 @@
 # Licensed under the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Ansible module for jsonrpc validate"""
+"""Ansible module for validating configuration on SR Linux devices"""
 from __future__ import absolute_import, division, print_function
 
 import json
@@ -19,10 +19,10 @@ __metaclass__ = type
 
 DOCUMENTATION = """
 ---
-module: jsonrpc_validate
-short_description: "Implementation of the Nokia SR Linux JSON-RPC's Validate method."
+module: validate
+short_description: "Validating configuration on SR Linux devices."
 description:
-  - This module allows to verify that the system accepts a configuration transaction before applying it to the system.
+  - Validating configuration on SR Linux devices using `commit validate` feature of SR Linux.
 version_added: "0.1.0"
 options:
   update:
@@ -80,7 +80,7 @@ author:
 
 EXAMPLES = """
 - name: Validate a valid change set
-  nokia.srlinux.jsonrpc_validate:
+  nokia.srlinux.validate:
     update:
       - path: /system/information
         value:

--- a/tests/playbooks/auth-fail.yml
+++ b/tests/playbooks/auth-fail.yml
@@ -9,7 +9,7 @@
     ansible_password: wrong
   tasks:
     - name: Get system information
-      nokia.srlinux.jsonrpc_get:
+      nokia.srlinux.get:
         paths:
           - path: /system/information
             datastore: state

--- a/tests/playbooks/backup-cfg.yml
+++ b/tests/playbooks/backup-cfg.yml
@@ -14,7 +14,7 @@
         - "/tmp/{{inventory_hostname}}.cfg.*"
 
     - name: Get entire running config
-      nokia.srlinux.jsonrpc_get:
+      nokia.srlinux.get:
         paths:
           - path: /
             datastore: running

--- a/tests/playbooks/cli-show-version.yml
+++ b/tests/playbooks/cli-show-version.yml
@@ -7,7 +7,7 @@
   gather_facts: false
   tasks:
     - name: Run "show version" CLI command
-      nokia.srlinux.jsonrpc_cli:
+      nokia.srlinux.cli:
         commands:
           - show version
       register: response

--- a/tests/playbooks/cli-wrong-cmd.yml
+++ b/tests/playbooks/cli-wrong-cmd.yml
@@ -7,7 +7,7 @@
   gather_facts: false
   tasks:
     - name: Run wrong CLI command
-      nokia.srlinux.jsonrpc_cli:
+      nokia.srlinux.cli:
         commands:
           - show wrong
       register: response

--- a/tests/playbooks/delete-leaves.yml
+++ b/tests/playbooks/delete-leaves.yml
@@ -8,7 +8,7 @@
   tasks:
     # test preparation step
     - name: Set system information with values
-      nokia.srlinux.jsonrpc_set:
+      nokia.srlinux.config:
         update:
           - path: /system/information
             value:
@@ -16,7 +16,7 @@
               contact: Some contact
 
     - name: Test Delete operation on leaf nodes
-      nokia.srlinux.jsonrpc_set:
+      nokia.srlinux.config:
         delete:
           - path: /system/information/location
           - path: /system/information/contact

--- a/tests/playbooks/delete-leaves.yml
+++ b/tests/playbooks/delete-leaves.yml
@@ -26,7 +26,7 @@
         var: delete_response
 
     - name: Ensure leaves were deleted
-      nokia.srlinux.jsonrpc_get:
+      nokia.srlinux.get:
         paths:
           - path: /system/information
             datastore: state

--- a/tests/playbooks/get-container.yml
+++ b/tests/playbooks/get-container.yml
@@ -8,7 +8,7 @@
   tasks:
     # this task ensures that we can get information for a container
     - name: Get /system/information container
-      nokia.srlinux.jsonrpc_get:
+      nokia.srlinux.get:
         paths:
           - path: /system/information
             datastore: state

--- a/tests/playbooks/get-wrong-path.yml
+++ b/tests/playbooks/get-wrong-path.yml
@@ -8,7 +8,7 @@
   tasks:
     # this task ensures that we fail with expected error when get is targeted to a wrong path
     - name: Get wrong path
-      nokia.srlinux.jsonrpc_get:
+      nokia.srlinux.get:
         paths:
           - path: /system/informations
             datastore: state

--- a/tests/playbooks/replace-full-cfg.yml
+++ b/tests/playbooks/replace-full-cfg.yml
@@ -19,7 +19,7 @@
         var: set_response
 
     - name: Ensure changes were made to the device
-      nokia.srlinux.jsonrpc_get:
+      nokia.srlinux.get:
         paths:
           - path: /interface[name=ethernet-1/1]/description
             datastore: state

--- a/tests/playbooks/replace-full-cfg.yml
+++ b/tests/playbooks/replace-full-cfg.yml
@@ -7,7 +7,7 @@
   gather_facts: false
   tasks:
     - name: Replace entire config from file
-      nokia.srlinux.jsonrpc_set:
+      nokia.srlinux.config:
         replace:
           - path: /
             value: "{{lookup('ansible.builtin.template', '{{playbook_dir}}/golden/{{inventory_hostname}}-golden.cfg.json.j2') }}"

--- a/tests/playbooks/set-check.yml
+++ b/tests/playbooks/set-check.yml
@@ -36,7 +36,7 @@
         var: set_response
 
     - name: Ensure no changes were made to the device
-      nokia.srlinux.jsonrpc_get:
+      nokia.srlinux.get:
         paths:
           - path: /system/information
             datastore: state

--- a/tests/playbooks/set-check.yml
+++ b/tests/playbooks/set-check.yml
@@ -7,7 +7,7 @@
   gather_facts: false
   tasks:
     - name: Test check mode
-      nokia.srlinux.jsonrpc_set:
+      nokia.srlinux.config:
         update:
           - path: /system/information
             value:
@@ -21,7 +21,7 @@
         var: set_response
 
     - name: Test check mode with diff
-      nokia.srlinux.jsonrpc_set:
+      nokia.srlinux.config:
         update:
           - path: /system/information
             value:

--- a/tests/playbooks/set-check.yml
+++ b/tests/playbooks/set-check.yml
@@ -7,7 +7,8 @@
   gather_facts: false
   tasks:
     - name: Test check mode
-      nokia.srlinux.config:
+      # srl_config module name tests the redirection to nokia.srlinux.config
+      nokia.srlinux.srl_config:
         update:
           - path: /system/information
             value:

--- a/tests/playbooks/set-idempotent.yml
+++ b/tests/playbooks/set-idempotent.yml
@@ -7,7 +7,7 @@
   gather_facts: false
   tasks:
     - name: Set system information with values
-      nokia.srlinux.jsonrpc_set:
+      nokia.srlinux.config:
         update:
           - path: /system/information
             value:
@@ -31,7 +31,7 @@
         var: get_response
 
     - name: Repeated set should not run
-      nokia.srlinux.jsonrpc_set:
+      nokia.srlinux.config:
         update:
           - path: /system/information
             value:
@@ -44,7 +44,7 @@
         var: set_response
 
     - name: Repeated set should not run with diff
-      nokia.srlinux.jsonrpc_set:
+      nokia.srlinux.config:
         update:
           - path: /system/information
             value:

--- a/tests/playbooks/set-idempotent.yml
+++ b/tests/playbooks/set-idempotent.yml
@@ -20,7 +20,7 @@
         var: set_response
 
     - name: Ensure changes were made to the device
-      nokia.srlinux.jsonrpc_get:
+      nokia.srlinux.get:
         paths:
           - path: /system/information
             datastore: state

--- a/tests/playbooks/set-leaves.yml
+++ b/tests/playbooks/set-leaves.yml
@@ -19,7 +19,7 @@
         var: set_response
 
     - name: Ensure changes were made to the device
-      nokia.srlinux.jsonrpc_get:
+      nokia.srlinux.get:
         paths:
           - path: /system/information
             datastore: state

--- a/tests/playbooks/set-leaves.yml
+++ b/tests/playbooks/set-leaves.yml
@@ -7,7 +7,7 @@
   gather_facts: false
   tasks:
     - name: Set system information with values
-      nokia.srlinux.jsonrpc_set:
+      nokia.srlinux.config:
         update:
           - path: /system/information
             value:

--- a/tests/playbooks/tls-missed-check-fail.yml
+++ b/tests/playbooks/tls-missed-check-fail.yml
@@ -9,7 +9,7 @@
     ansible_httpapi_use_ssl: yes
   tasks:
     - name: json RPC get
-      nokia.srlinux.jsonrpc_get:
+      nokia.srlinux.get:
         paths:
           - path: /system/information
             datastore: state

--- a/tests/playbooks/tls-skipped-check.yml
+++ b/tests/playbooks/tls-skipped-check.yml
@@ -10,7 +10,7 @@
     ansible_httpapi_validate_certs: no
   tasks:
     - name: json RPC get
-      nokia.srlinux.jsonrpc_get:
+      nokia.srlinux.get:
         paths:
           - path: /system/information
             datastore: state

--- a/tests/playbooks/validate.yml
+++ b/tests/playbooks/validate.yml
@@ -7,7 +7,7 @@
   gather_facts: false
   tasks:
     - name: Validate a valid change set
-      nokia.srlinux.jsonrpc_validate:
+      nokia.srlinux.validate:
         update:
           - path: /system/information
             value:
@@ -19,7 +19,7 @@
         var: response
 
     - name: Validate an invalid change set
-      nokia.srlinux.jsonrpc_validate:
+      nokia.srlinux.validate:
         update:
           - path: /system/information
             value:

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -4,10 +4,10 @@ plugins/modules/jsonrpc_cli.py import-2.7!skip # srlinux collection requires py3
 plugins/modules/jsonrpc_cli.py import-3.5!skip
 plugins/modules/jsonrpc_cli.py validate-modules:missing-gplv3-license
 plugins/modules/jsonrpc_cli.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_get.py import-2.7!skip
-plugins/modules/jsonrpc_get.py import-3.5!skip
-plugins/modules/jsonrpc_get.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_get.py validate-modules:import-before-documentation
+plugins/modules/get.py import-2.7!skip
+plugins/modules/get.py import-3.5!skip
+plugins/modules/get.py validate-modules:missing-gplv3-license
+plugins/modules/get.py validate-modules:import-before-documentation
 plugins/modules/config.py import-2.7!skip
 plugins/modules/config.py import-3.5!skip
 plugins/modules/config.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -12,10 +12,10 @@ plugins/modules/config.py import-2.7!skip
 plugins/modules/config.py import-3.5!skip
 plugins/modules/config.py validate-modules:missing-gplv3-license
 plugins/modules/config.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_validate.py import-2.7!skip
-plugins/modules/jsonrpc_validate.py import-3.5!skip
-plugins/modules/jsonrpc_validate.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_validate.py validate-modules:import-before-documentation
+plugins/modules/validate.py import-2.7!skip
+plugins/modules/validate.py import-3.5!skip
+plugins/modules/validate.py validate-modules:missing-gplv3-license
+plugins/modules/validate.py validate-modules:import-before-documentation
 plugins/module_utils/srlinux.py import-2.7!skip
 plugins/module_utils/srlinux.py import-3.5!skip
 plugins/module_utils/const.py import-2.7!skip

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -8,10 +8,10 @@ plugins/modules/jsonrpc_get.py import-2.7!skip
 plugins/modules/jsonrpc_get.py import-3.5!skip
 plugins/modules/jsonrpc_get.py validate-modules:missing-gplv3-license
 plugins/modules/jsonrpc_get.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_set.py import-2.7!skip
-plugins/modules/jsonrpc_set.py import-3.5!skip
-plugins/modules/jsonrpc_set.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_set.py validate-modules:import-before-documentation
+plugins/modules/config.py import-2.7!skip
+plugins/modules/config.py import-3.5!skip
+plugins/modules/config.py validate-modules:missing-gplv3-license
+plugins/modules/config.py validate-modules:import-before-documentation
 plugins/modules/jsonrpc_validate.py import-2.7!skip
 plugins/modules/jsonrpc_validate.py import-3.5!skip
 plugins/modules/jsonrpc_validate.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,9 +1,9 @@
 plugins/httpapi/srlinux.py validate-modules:missing-gplv3-license
 plugins/httpapi/srlinux.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_cli.py import-2.7!skip # srlinux collection requires py3.6+
-plugins/modules/jsonrpc_cli.py import-3.5!skip
-plugins/modules/jsonrpc_cli.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_cli.py validate-modules:import-before-documentation
+plugins/modules/cli.py import-2.7!skip # srlinux collection requires py3.6+
+plugins/modules/cli.py import-3.5!skip
+plugins/modules/cli.py validate-modules:missing-gplv3-license
+plugins/modules/cli.py validate-modules:import-before-documentation
 plugins/modules/get.py import-2.7!skip
 plugins/modules/get.py import-3.5!skip
 plugins/modules/get.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -4,10 +4,10 @@ plugins/modules/jsonrpc_cli.py import-2.7!skip # srlinux collection requires py3
 plugins/modules/jsonrpc_cli.py import-3.5!skip
 plugins/modules/jsonrpc_cli.py validate-modules:missing-gplv3-license
 plugins/modules/jsonrpc_cli.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_get.py import-2.7!skip
-plugins/modules/jsonrpc_get.py import-3.5!skip
-plugins/modules/jsonrpc_get.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_get.py validate-modules:import-before-documentation
+plugins/modules/get.py import-2.7!skip
+plugins/modules/get.py import-3.5!skip
+plugins/modules/get.py validate-modules:missing-gplv3-license
+plugins/modules/get.py validate-modules:import-before-documentation
 plugins/modules/config.py import-2.7!skip
 plugins/modules/config.py import-3.5!skip
 plugins/modules/config.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -12,10 +12,10 @@ plugins/modules/config.py import-2.7!skip
 plugins/modules/config.py import-3.5!skip
 plugins/modules/config.py validate-modules:missing-gplv3-license
 plugins/modules/config.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_validate.py import-2.7!skip
-plugins/modules/jsonrpc_validate.py import-3.5!skip
-plugins/modules/jsonrpc_validate.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_validate.py validate-modules:import-before-documentation
+plugins/modules/validate.py import-2.7!skip
+plugins/modules/validate.py import-3.5!skip
+plugins/modules/validate.py validate-modules:missing-gplv3-license
+plugins/modules/validate.py validate-modules:import-before-documentation
 plugins/module_utils/srlinux.py import-2.7!skip
 plugins/module_utils/srlinux.py import-3.5!skip
 plugins/module_utils/const.py import-2.7!skip

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -8,10 +8,10 @@ plugins/modules/jsonrpc_get.py import-2.7!skip
 plugins/modules/jsonrpc_get.py import-3.5!skip
 plugins/modules/jsonrpc_get.py validate-modules:missing-gplv3-license
 plugins/modules/jsonrpc_get.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_set.py import-2.7!skip
-plugins/modules/jsonrpc_set.py import-3.5!skip
-plugins/modules/jsonrpc_set.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_set.py validate-modules:import-before-documentation
+plugins/modules/config.py import-2.7!skip
+plugins/modules/config.py import-3.5!skip
+plugins/modules/config.py validate-modules:missing-gplv3-license
+plugins/modules/config.py validate-modules:import-before-documentation
 plugins/modules/jsonrpc_validate.py import-2.7!skip
 plugins/modules/jsonrpc_validate.py import-3.5!skip
 plugins/modules/jsonrpc_validate.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,9 +1,9 @@
 plugins/httpapi/srlinux.py validate-modules:missing-gplv3-license
 plugins/httpapi/srlinux.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_cli.py import-2.7!skip # srlinux collection requires py3.6+
-plugins/modules/jsonrpc_cli.py import-3.5!skip
-plugins/modules/jsonrpc_cli.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_cli.py validate-modules:import-before-documentation
+plugins/modules/cli.py import-2.7!skip # srlinux collection requires py3.6+
+plugins/modules/cli.py import-3.5!skip
+plugins/modules/cli.py validate-modules:missing-gplv3-license
+plugins/modules/cli.py validate-modules:import-before-documentation
 plugins/modules/get.py import-2.7!skip
 plugins/modules/get.py import-3.5!skip
 plugins/modules/get.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -4,10 +4,10 @@ plugins/modules/jsonrpc_cli.py import-2.7!skip # srlinux collection requires py3
 plugins/modules/jsonrpc_cli.py import-3.5!skip
 plugins/modules/jsonrpc_cli.py validate-modules:missing-gplv3-license
 plugins/modules/jsonrpc_cli.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_get.py import-2.7!skip
-plugins/modules/jsonrpc_get.py import-3.5!skip
-plugins/modules/jsonrpc_get.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_get.py validate-modules:import-before-documentation
+plugins/modules/get.py import-2.7!skip
+plugins/modules/get.py import-3.5!skip
+plugins/modules/get.py validate-modules:missing-gplv3-license
+plugins/modules/get.py validate-modules:import-before-documentation
 plugins/modules/config.py import-2.7!skip
 plugins/modules/config.py import-3.5!skip
 plugins/modules/config.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -12,10 +12,10 @@ plugins/modules/config.py import-2.7!skip
 plugins/modules/config.py import-3.5!skip
 plugins/modules/config.py validate-modules:missing-gplv3-license
 plugins/modules/config.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_validate.py import-2.7!skip
-plugins/modules/jsonrpc_validate.py import-3.5!skip
-plugins/modules/jsonrpc_validate.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_validate.py validate-modules:import-before-documentation
+plugins/modules/validate.py import-2.7!skip
+plugins/modules/validate.py import-3.5!skip
+plugins/modules/validate.py validate-modules:missing-gplv3-license
+plugins/modules/validate.py validate-modules:import-before-documentation
 plugins/module_utils/srlinux.py import-2.7!skip
 plugins/module_utils/srlinux.py import-3.5!skip
 plugins/module_utils/const.py import-2.7!skip

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -8,10 +8,10 @@ plugins/modules/jsonrpc_get.py import-2.7!skip
 plugins/modules/jsonrpc_get.py import-3.5!skip
 plugins/modules/jsonrpc_get.py validate-modules:missing-gplv3-license
 plugins/modules/jsonrpc_get.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_set.py import-2.7!skip
-plugins/modules/jsonrpc_set.py import-3.5!skip
-plugins/modules/jsonrpc_set.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_set.py validate-modules:import-before-documentation
+plugins/modules/config.py import-2.7!skip
+plugins/modules/config.py import-3.5!skip
+plugins/modules/config.py validate-modules:missing-gplv3-license
+plugins/modules/config.py validate-modules:import-before-documentation
 plugins/modules/jsonrpc_validate.py import-2.7!skip
 plugins/modules/jsonrpc_validate.py import-3.5!skip
 plugins/modules/jsonrpc_validate.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,9 +1,9 @@
 plugins/httpapi/srlinux.py validate-modules:missing-gplv3-license
 plugins/httpapi/srlinux.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_cli.py import-2.7!skip # srlinux collection requires py3.6+
-plugins/modules/jsonrpc_cli.py import-3.5!skip
-plugins/modules/jsonrpc_cli.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_cli.py validate-modules:import-before-documentation
+plugins/modules/cli.py import-2.7!skip # srlinux collection requires py3.6+
+plugins/modules/cli.py import-3.5!skip
+plugins/modules/cli.py validate-modules:missing-gplv3-license
+plugins/modules/cli.py validate-modules:import-before-documentation
 plugins/modules/get.py import-2.7!skip
 plugins/modules/get.py import-3.5!skip
 plugins/modules/get.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -4,10 +4,10 @@ plugins/modules/jsonrpc_cli.py import-2.7!skip # srlinux collection requires py3
 plugins/modules/jsonrpc_cli.py import-3.5!skip
 plugins/modules/jsonrpc_cli.py validate-modules:missing-gplv3-license
 plugins/modules/jsonrpc_cli.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_get.py import-2.7!skip
-plugins/modules/jsonrpc_get.py import-3.5!skip
-plugins/modules/jsonrpc_get.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_get.py validate-modules:import-before-documentation
+plugins/modules/get.py import-2.7!skip
+plugins/modules/get.py import-3.5!skip
+plugins/modules/get.py validate-modules:missing-gplv3-license
+plugins/modules/get.py validate-modules:import-before-documentation
 plugins/modules/config.py import-2.7!skip
 plugins/modules/config.py import-3.5!skip
 plugins/modules/config.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -12,10 +12,10 @@ plugins/modules/config.py import-2.7!skip
 plugins/modules/config.py import-3.5!skip
 plugins/modules/config.py validate-modules:missing-gplv3-license
 plugins/modules/config.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_validate.py import-2.7!skip
-plugins/modules/jsonrpc_validate.py import-3.5!skip
-plugins/modules/jsonrpc_validate.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_validate.py validate-modules:import-before-documentation
+plugins/modules/validate.py import-2.7!skip
+plugins/modules/validate.py import-3.5!skip
+plugins/modules/validate.py validate-modules:missing-gplv3-license
+plugins/modules/validate.py validate-modules:import-before-documentation
 plugins/module_utils/srlinux.py import-2.7!skip
 plugins/module_utils/srlinux.py import-3.5!skip
 plugins/module_utils/const.py import-2.7!skip

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -8,10 +8,10 @@ plugins/modules/jsonrpc_get.py import-2.7!skip
 plugins/modules/jsonrpc_get.py import-3.5!skip
 plugins/modules/jsonrpc_get.py validate-modules:missing-gplv3-license
 plugins/modules/jsonrpc_get.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_set.py import-2.7!skip
-plugins/modules/jsonrpc_set.py import-3.5!skip
-plugins/modules/jsonrpc_set.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_set.py validate-modules:import-before-documentation
+plugins/modules/config.py import-2.7!skip
+plugins/modules/config.py import-3.5!skip
+plugins/modules/config.py validate-modules:missing-gplv3-license
+plugins/modules/config.py validate-modules:import-before-documentation
 plugins/modules/jsonrpc_validate.py import-2.7!skip
 plugins/modules/jsonrpc_validate.py import-3.5!skip
 plugins/modules/jsonrpc_validate.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,9 +1,9 @@
 plugins/httpapi/srlinux.py validate-modules:missing-gplv3-license
 plugins/httpapi/srlinux.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_cli.py import-2.7!skip # srlinux collection requires py3.6+
-plugins/modules/jsonrpc_cli.py import-3.5!skip
-plugins/modules/jsonrpc_cli.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_cli.py validate-modules:import-before-documentation
+plugins/modules/cli.py import-2.7!skip # srlinux collection requires py3.6+
+plugins/modules/cli.py import-3.5!skip
+plugins/modules/cli.py validate-modules:missing-gplv3-license
+plugins/modules/cli.py validate-modules:import-before-documentation
 plugins/modules/get.py import-2.7!skip
 plugins/modules/get.py import-3.5!skip
 plugins/modules/get.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -4,10 +4,10 @@ plugins/modules/jsonrpc_cli.py import-2.7!skip # srlinux collection requires py3
 plugins/modules/jsonrpc_cli.py import-3.5!skip
 plugins/modules/jsonrpc_cli.py validate-modules:missing-gplv3-license
 plugins/modules/jsonrpc_cli.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_get.py import-2.7!skip
-plugins/modules/jsonrpc_get.py import-3.5!skip
-plugins/modules/jsonrpc_get.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_get.py validate-modules:import-before-documentation
+plugins/modules/get.py import-2.7!skip
+plugins/modules/get.py import-3.5!skip
+plugins/modules/get.py validate-modules:missing-gplv3-license
+plugins/modules/get.py validate-modules:import-before-documentation
 plugins/modules/config.py import-2.7!skip
 plugins/modules/config.py import-3.5!skip
 plugins/modules/config.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -12,10 +12,10 @@ plugins/modules/config.py import-2.7!skip
 plugins/modules/config.py import-3.5!skip
 plugins/modules/config.py validate-modules:missing-gplv3-license
 plugins/modules/config.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_validate.py import-2.7!skip
-plugins/modules/jsonrpc_validate.py import-3.5!skip
-plugins/modules/jsonrpc_validate.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_validate.py validate-modules:import-before-documentation
+plugins/modules/validate.py import-2.7!skip
+plugins/modules/validate.py import-3.5!skip
+plugins/modules/validate.py validate-modules:missing-gplv3-license
+plugins/modules/validate.py validate-modules:import-before-documentation
 plugins/module_utils/srlinux.py import-2.7!skip
 plugins/module_utils/srlinux.py import-3.5!skip
 plugins/module_utils/const.py import-2.7!skip

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -8,10 +8,10 @@ plugins/modules/jsonrpc_get.py import-2.7!skip
 plugins/modules/jsonrpc_get.py import-3.5!skip
 plugins/modules/jsonrpc_get.py validate-modules:missing-gplv3-license
 plugins/modules/jsonrpc_get.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_set.py import-2.7!skip
-plugins/modules/jsonrpc_set.py import-3.5!skip
-plugins/modules/jsonrpc_set.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_set.py validate-modules:import-before-documentation
+plugins/modules/config.py import-2.7!skip
+plugins/modules/config.py import-3.5!skip
+plugins/modules/config.py validate-modules:missing-gplv3-license
+plugins/modules/config.py validate-modules:import-before-documentation
 plugins/modules/jsonrpc_validate.py import-2.7!skip
 plugins/modules/jsonrpc_validate.py import-3.5!skip
 plugins/modules/jsonrpc_validate.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,9 +1,9 @@
 plugins/httpapi/srlinux.py validate-modules:missing-gplv3-license
 plugins/httpapi/srlinux.py validate-modules:import-before-documentation
-plugins/modules/jsonrpc_cli.py import-2.7!skip # srlinux collection requires py3.6+
-plugins/modules/jsonrpc_cli.py import-3.5!skip
-plugins/modules/jsonrpc_cli.py validate-modules:missing-gplv3-license
-plugins/modules/jsonrpc_cli.py validate-modules:import-before-documentation
+plugins/modules/cli.py import-2.7!skip # srlinux collection requires py3.6+
+plugins/modules/cli.py import-3.5!skip
+plugins/modules/cli.py validate-modules:missing-gplv3-license
+plugins/modules/cli.py validate-modules:import-before-documentation
 plugins/modules/get.py import-2.7!skip
 plugins/modules/get.py import-3.5!skip
 plugins/modules/get.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
* jsonrpc_set -> config
* jsonrpc_get -> get
* jsonrpc_cli -> cli
* jsonrpc_validate -> validate


Added [plugin routing](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structure.html#meta-directory-and-runtime-yml) to enable `nokia.srlinux.srl_config` to point to `nokia.srlinux.config` and same for get.