### PR TITLE
Exit early when diff is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ansible Collection to manage Nokia SR Linux devices. Documentation is provided at <https://learn.srlinux.dev/ansible/collection/>
 
-## Dev setup
+## Quick start for developers
 
 Start with cloning the repo:
 
@@ -17,7 +17,7 @@ Deploy the lab to support the tests:
 ./run.sh deploy-lab
 ```
 
-Run the automated suite of tests to make sure nothing is missing. This will also prepare a dev environment
+Run the automated suite of tests to make sure nothing is missing. This will also prepare a dev environment (you have to make sure the venv with ansible is activated or ansible-playbook is in your path):
 
 ```bash
 ./run.sh test
@@ -27,4 +27,20 @@ To validate that the code passes Ansible's sanity check, run:
 
 ```bash
 ./run.sh sanity-test
+```
+
+Note, that the lab uses IXR-6 chassis, which only runs for 5 minutes without a license. This is enough to finish the test suite, but if you want to play with the lab for a longer period, remove the type or provide a license.
+
+### Running individual tests
+
+To run an individual test, first make sure that the local code base is used by ansible. This can be done by running:
+
+```bash
+./run.sh prepare-dev-env
+```
+
+Then either run one of the provided test playbooks (defined in [run.sh](run.sh)) or run your own:
+
+```bash
+./run.sh test-set-leaves
 ```

--- a/plugins/modules/config.py
+++ b/plugins/modules/config.py
@@ -212,6 +212,11 @@ def main():
             msg = diff_resp.get("error", {}).get("message", "No diff response")
             module.fail_json(msg=msg, method="diff", id=diff_resp["jsonrpc_req_id"])
 
+        # if diff response is empty, the operation is a noop and we can exit the module
+        if not [x for x in diff_resp.get("result") if x.strip() != ""]:
+            json_output["jsonrpc_req_id"] = diff_resp["jsonrpc_req_id"]
+            module.exit_json(**json_output)
+
     # if diff response is not empty, we have a diff
     # we need to set the changed flag to True
     # and save the diff response result in the json_output

--- a/run.sh
+++ b/run.sh
@@ -190,6 +190,15 @@ function test-set-leaves {
   ansible-playbook playbooks/set-leaves.yml "$@"
 }
 
+# test that subsequent config changes are idempotent
+# and does not lead to commit being recorded since
+# the diff is empty
+function test-set-leaves-twice {
+  _cdTests
+  revert-to-checkpoint
+  ansible-playbook playbooks/set-leaves-twice.yml "$@"
+}
+
 function test-set-interface {
   _cdTests
   revert-to-checkpoint
@@ -269,6 +278,7 @@ function _run-tests {
   test-tls-skip "$@"
   test-set-check-mode "$@"
   test-set-leaves "$@"
+  test-set-leaves-twice "$@"
   test-set-wrong-value "$@"
   test-set-multiple-paths "$@"
   test-set-interface "$@"

--- a/scripts/topo.clab.yml
+++ b/scripts/topo.clab.yml
@@ -7,8 +7,8 @@ name: ansible
 topology:
   nodes:
     srl:
-      kind: srl
-      image: ghcr.io/nokia/srlinux:${SRLINUX_VERSION:=23.7.2}
+      kind: nokia_srlinux
+      image: ghcr.io/nokia/srlinux:${SRLINUX_VERSION:=23.10.1}
       # type and startup config are used to test Openconfig modules
       type: ixr6
       startup-config: oc.cfg

--- a/tests/playbooks/set-leaves-twice.yml
+++ b/tests/playbooks/set-leaves-twice.yml
@@ -1,0 +1,79 @@
+# Copyright 2023 Nokia
+# Licensed under the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+
+- name: Set leaves
+  hosts: clab
+  gather_facts: false
+  tasks:
+    - name: Set system information with values
+      nokia.srlinux.config:
+        update:
+          - path: /system/information
+            value:
+              location: some location
+      register: set_response
+
+    - debug:
+        var: set_response
+
+    - name: Ensure changes were made to the device
+      nokia.srlinux.get:
+        paths:
+          - path: /system/information
+            datastore: state
+      register: get_response
+      failed_when: (get_response.result[0].location != "some location")
+
+    - debug:
+        var: get_response
+
+    - name: get commits
+      nokia.srlinux.get:
+        paths:
+          - path: /system/configuration/commit
+      register: commits
+
+    - debug:
+        var: commits
+
+    - name: Count the number of commits registered after the first set
+      set_fact:
+        first_commit_count: "{{ commits.result[0].commit | length }}"
+
+    - name: Set information with the same value again
+      nokia.srlinux.config:
+        update:
+          - path: /system/information
+            value:
+              location: some location
+      register: set_response
+
+    - debug:
+        var: set_response
+
+    - name: check that no change has been recorded by the module
+      assert:
+        that:
+          - set_response.changed is false
+
+    - name: get commits again
+      nokia.srlinux.get:
+        paths:
+          - path: /system/configuration/commit
+      register: commits
+
+    - debug:
+        var: commits
+
+    - name: Count the number of commits registered after the second set
+      set_fact:
+        second_commit_count: "{{ commits.result[0].commit | length }}"
+
+    - debug:
+        msg: "1st commit count is: {{ first_commit_count }}, 2nd commit count is: {{ second_commit_count }}"
+
+    - name: check that no new commits have been recorded
+      assert:
+        that:
+          - first_commit_count == second_commit_count


### PR DESCRIPTION
fix #22 

We didn't exit from the config module when the diff for a change was empty. This caused empty commits to be registered and this shouldn't have happened.

This PR fixes it by checking if the diff empty and if it is, exists the module.