### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -49,7 +49,7 @@ jobs:
         id: core-image
         run: |
           CORE_VERSION=$(./run.sh _transformAnsibleCoreVersion "${{ matrix.ansible-core-image }}")
-          echo "::set-output name=core-version::$CORE_VERSION"
+          echo "core-version=$CORE_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter