### PR TITLE
Make plugin work with native Jinja2

### DIFF
--- a/plugins/modules/config.py
+++ b/plugins/modules/config.py
@@ -53,7 +53,7 @@ options:
         type: str
         required: true
       value:
-        type: raw
+        type: dict
         description:
           - values to update
   delete:
@@ -84,7 +84,7 @@ options:
         description:
           - values to replace
         required: true
-        type: raw
+        type: dict
   datastore:
     type: str
     description:
@@ -132,7 +132,7 @@ def main():
             "required": False,
             "options": {
                 "path": {"type": "str", "required": True},
-                "value": {"type": "raw"},
+                "value": {"type": "dict"},
             },
         },
         "delete": {
@@ -149,7 +149,7 @@ def main():
             "required": False,
             "options": {
                 "path": {"type": "str", "required": True},
-                "value": {"type": "raw", "required": True},
+                "value": {"type": "dict", "required": True},
             },
         },
         "save_when": {"choices": ["always", "never", "changed"], "default": "never"},


### PR DESCRIPTION
When enabling [jinja2_native](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-jinja2-native) the update and replace functionality breaks with the following message:

```
JSON data for schema node must start with an object or with a list: Parse error on line 1: "{\n   ...
```
My understanding is that this happens because Jinja struggles to parse the raw types in the plugin. When changing these types to their proper type; `dict` the plugin works with jinja2_native enabled.

Steps to reproduce:
- Set the following in your ansible.cfg
```
jinja2_native = true
```

Full error:
```
fatal: [hostname]: FAILED! => {
    "changed": false,
    "id": "2024-08-26 12:01:58:293448",
    "invocation": {
        "module_args": {
            "confirm_timeout": null,
            "datastore": "candidate",
            "delete": null,
            "replace": [
                {
                    "action": "replace",
                    "path": "/",
                   "value": "{\n <config>
                }
            ],
            "save_when": "never",
            "update": null,
            "yang_models": "srl"
        }
    },
    "method": "diff"
}

MSG:

JSON data for schema node must start with an object or with a list: Parse error on line 1: "{\n   <config>
Input:
'"{\n<config>
```
