### PR TITLE
Fix value type for the validate module `dict -> raw`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ To validate that the code passes Ansible's sanity check, run:
 ./run.sh sanity-test
 ```
 
-Note, that the lab uses IXR-6 chassis, which only runs for 5 minutes without a license. This is enough to finish the test suite, but if you want to play with the lab for a longer period, remove the type or provide a license.
-
 ### Running individual tests
 
 To run an individual test, first make sure that the local code base is used by ansible. This can be done by running:

--- a/plugins/modules/validate.py
+++ b/plugins/modules/validate.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 """Ansible module for validating configuration on SR Linux devices"""
+
 from __future__ import absolute_import, division, print_function
 
 import json
@@ -41,7 +42,7 @@ options:
         type: str
         required: true
       value:
-        type: dict
+        type: raw
         description:
           - values to update
         required: true
@@ -109,7 +110,7 @@ def main():
             "required": False,
             "options": {
                 "path": {"type": "str", "required": True},
-                "value": {"type": "dict", "required": True},
+                "value": {"type": "raw", "required": True},
             },
         },
         "delete": {
@@ -126,7 +127,7 @@ def main():
             "required": False,
             "options": {
                 "path": {"type": "str", "required": True},
-                "value": {"type": "dict", "required": True},
+                "value": {"type": "raw", "required": True},
             },
         },
         "yang_models": {"choices": ["srl", "oc"], "default": "srl"},

--- a/plugins/modules/validate.py
+++ b/plugins/modules/validate.py
@@ -74,7 +74,7 @@ options:
         description:
           - values to replace
         required: true
-        type: dict
+        type: raw
   yang_models:
     type: str
     description:

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,9 @@ SCRIPTS_DIR="scripts"
 TESTS_DIR="$(pwd)/tests"
 
 # Containerlab version to use in CI tests
-CLAB_VERSION="0.55.1"
+CLAB_VERSION="0.57.5"
+
+CHECKPOINT_NAME="clab-initial"
 
 # -----------------------------------------------------------------------------
 # Helper functions start with _ and aren't listed in this script's help menu.
@@ -65,8 +67,6 @@ function remove-local-collection {
 function deploy-lab {
   cd ${SCRIPTS_DIR}
   sudo -E containerlab deploy -c
-  # generate a checkpoint named "initial" that we can revert to to guarantee a clean state
-  docker exec ${NODE_NAME} sr_cli /tools system configuration generate-checkpoint name initial
 }
 
 # Prepare local dev environment by setting the symlink to the collection.
@@ -83,7 +83,7 @@ function prepare-dev-env {
 # revert to initial checkpoint to guarantee the node initial state
 function revert-to-checkpoint {
   # revert to the checkpoint named "initial" to guarantee a clean state
-  docker exec ${NODE_NAME} sr_cli /tools system configuration checkpoint initial revert
+  docker exec ${NODE_NAME} sr_cli /tools system configuration checkpoint ${CHECKPOINT_NAME} revert
 }
 
 

--- a/scripts/topo.clab.yml
+++ b/scripts/topo.clab.yml
@@ -8,4 +8,4 @@ topology:
   nodes:
     srl:
       kind: nokia_srlinux
-      image: ghcr.io/nokia/srlinux:${SRLINUX_VERSION:=24.3.2}
+      image: ghcr.io/nokia/srlinux:${SRLINUX_VERSION:=24.7.2}

--- a/tests/playbooks/validate.yml
+++ b/tests/playbooks/validate.yml
@@ -18,6 +18,16 @@
     - debug:
         var: response
 
+    - name: Validate a valid change set using the non dict value
+      nokia.srlinux.validate:
+        update:
+          - path: /system/information/location
+            value: Some location
+      register: response
+
+    - debug:
+        var: response
+
     - name: Validate an invalid change set
       nokia.srlinux.validate:
         update:


### PR DESCRIPTION
To allow validation of the path/value pairs, where path points to a leaf:

```yaml
    - name: Validate a valid change set using the non dict value
      nokia.srlinux.validate:
        update:
          - path: /system/information/location
            value: Some location
```