### PR TITLE
fix(validate): honor delete operations

### DIFF
--- a/plugins/modules/validate.py
+++ b/plugins/modules/validate.py
@@ -138,19 +138,19 @@ def main():
     client = JSONRPCClient(module)
 
     updates = module.params.get("update") or []
-    deletes = module.params.get("deletes") or []
+    deletes = module.params.get("delete") or []
     replaces = module.params.get("replace") or []
     yang_models = module.params.get("yang_models")
 
     commands = []
-    for obj in updates:
-        obj["action"] = "update"
+    for obj in deletes:
+        obj["action"] = "delete"
         commands += [obj]
     for obj in replaces:
         obj["action"] = "replace"
         commands += [obj]
-    for obj in deletes:
-        obj["action"] = "delete"
+    for obj in updates:
+        obj["action"] = "update"
         commands += [obj]
 
     data = {


### PR DESCRIPTION
## Problem

`nokia.srlinux.validate` documents and accepts a `delete` argument, but the module reads `module.params.get("deletes")`. Because `deletes` is not an argspec key, delete operations are dropped before the JSON-RPC `validate` request is sent.

This can make a delete-only validation task validate an empty command list instead of the requested delete operation.

The module also builds validate commands as `update -> replace -> delete`, while `nokia.srlinux.config` applies commands as `delete -> replace -> update`. Validation should rehearse the same transaction shape that apply uses.

## Solution

This change keeps the fix intentionally narrow:

- Read delete operations from the documented `delete` parameter.
- Build validate commands in the same order as `config.py`: `delete -> replace -> update`.

No module API changes are introduced. No dependencies, test infrastructure, generated files, or unrelated cleanup are included.

## Why this shape

The external module parameter is already `delete`; the local Python variable can remain `deletes` because it holds a list of delete operations. The bug is only the lookup key.

Matching `config.py` ordering avoids validating one transaction shape and then applying another. `config.py` was intentionally changed to this order in PR #31 (`delete -> replace -> update`); this keeps `validate.py` aligned with that newer behavior.

## Testing

Narrow sanity check for the touched module:

```bash
uv run --python 3.12 ansible-test sanity \
  --test validate-modules \
  --python 3.12 \
  plugins/modules/validate.py
```

Result:

```text
Running sanity test "validate-modules"
```

## Reviewer focus

Please verify:

- The fix is limited to `nokia.srlinux.validate`.
- The module reads `delete`, not `deletes`.
- The validate command order matches `nokia.srlinux.config`.
- No dependencies, generated files, CI changes, or unrelated cleanup are part of the branch.
